### PR TITLE
feat: typography tokens defined

### DIFF
--- a/libs/slushy/.storybook/documentation/color-palette.mdx
+++ b/libs/slushy/.storybook/documentation/color-palette.mdx
@@ -1,8 +1,9 @@
-import { ColorPalette, ColorItem, Meta, Title, Subtitle } from '@storybook/blocks';
+import { ColorPalette, ColorItem, Meta, Title, Subtitle, Unstyled } from '@storybook/blocks';
 import { getCSSVariable } from './helper.ts';
 
 <Meta title="Foundations/Colors" />
 
+<Unstyled>
 # Colors
 
 Basic color palette for Slushy component catalog.
@@ -97,3 +98,4 @@ Basic color palette for Slushy component catalog.
       }}
     />
   </ColorPalette>
+</Unstyled>

--- a/libs/slushy/.storybook/documentation/typography.mdx
+++ b/libs/slushy/.storybook/documentation/typography.mdx
@@ -1,0 +1,67 @@
+import { Meta, Title, Unstyled } from '@storybook/blocks';
+import { getCSSVariable } from './helper.ts';
+
+<Meta title="Foundations/Typography" />
+
+<Unstyled>
+# Typography
+
+We have defined the typography foundation for Slushy with **IBM Plex Serif** font ensuring consistency in typography styles across different components.
+
+## Global Typography Styles
+
+The following CSS rules apply the IBM Plex Serif font globally across the app:
+
+### 1. **Base Font Style**
+All elements use the **IBM Plex Serif** font by default with a regular weight of 400 and normal style.
+
+```css
+* {
+    font-family: "IBM Plex Serif", serif;
+    font-weight: 400; /* Default regular weight */
+    font-style: normal;
+}
+```
+
+### 2. **Body Text**
+The body text inherits the default font style, which is regular weight (400) and normal style.
+
+```css
+body {
+    font-family: "IBM Plex Serif", serif;
+    font-weight: 400; /* Regular weight */
+    font-style: normal;
+}
+```
+
+### 3. **Headings**
+Headings (`h1`, `h2`, `h3`, `h4`, `h5`, `h6`) use a **semibold** weight (600) for a stronger emphasis and differentiation from the body text.
+
+```css
+h1, h2, h3, h4, h5, h6 {
+    font-family: "IBM Plex Serif", serif;
+    font-weight: 600; /* Semibold weight for headings */
+}
+```
+
+### 4. **Paragraphs**
+Paragraphs (`p`) are styled with a regular weight (400) to keep them consistent with the body text.
+
+```css
+p {
+    font-family: "IBM Plex Serif", serif;
+    font-weight: 400; /* Regular weight for paragraphs */
+}
+```
+
+### 5. **Emphasized Text**
+Emphasized text, such as `<em>` and `<i>`, is styled with a **light** weight (300) and **italic** style for a more subtle emphasis.
+
+```css
+em, i {
+    font-family: "IBM Plex Serif", serif;
+    font-weight: 300; /* Light weight for emphasized text */
+    font-style: italic;
+}
+```
+</Unstyled>

--- a/libs/slushy/.storybook/documentation/typography.mdx
+++ b/libs/slushy/.storybook/documentation/typography.mdx
@@ -1,5 +1,4 @@
 import { Meta, Title, Unstyled } from '@storybook/blocks';
-import { getCSSVariable } from './helper.ts';
 
 <Meta title="Foundations/Typography" />
 

--- a/libs/slushy/scss/abstracts/index.scss
+++ b/libs/slushy/scss/abstracts/index.scss
@@ -1,1 +1,2 @@
 @use 'colors';
+@use 'typography';

--- a/libs/slushy/scss/abstracts/typography/index.scss
+++ b/libs/slushy/scss/abstracts/typography/index.scss
@@ -1,0 +1,29 @@
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Serif:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&display=swap');
+
+* {
+    font-family: "IBM Plex Serif", serif;
+    font-weight: 400; /* Default regular weight */
+    font-style: normal;
+}
+
+body {
+    font-family: "IBM Plex Serif", serif;
+    font-weight: 400; /* Regular weight */
+    font-style: normal;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: "IBM Plex Serif", serif;
+    font-weight: 600; /* Semibold weight for headings */
+}
+
+p {
+    font-family: "IBM Plex Serif", serif;
+    font-weight: 400; /* Regular weight for paragraphs */
+}
+
+em, i {
+    font-family: "IBM Plex Serif", serif;
+    font-weight: 300; /* Light weight for emphasized text */
+    font-style: italic;
+}


### PR DESCRIPTION
This PR introduces a typography tokens (IBM Plex Serif) as CSS-based @import from Google Fonts which are configured in Storybook's preview.ts API. 

Below are the changes made:
- Created .mdx files for strict documentation usage
- Define typography under abstracts directory in SCSS folder directories
- Added `<Unstyled>` tag in Colors MDX file to use new font instead of Storybook's native font